### PR TITLE
Deploy: Pass react env variables to github action

### DIFF
--- a/.github/workflows/surge.yml
+++ b/.github/workflows/surge.yml
@@ -22,6 +22,8 @@ jobs:
       -
         name: 'Build react app'
         run: 'yarn run build:web'
+        env:
+          REACT_APP_API_ENDPOINT: ${{ secrets.REACT_APP_API_ENDPOINT }}
       -
         name: 'Deploy react app to surge.sh'
         uses: dswistowski/surge-sh-action@v1


### PR DESCRIPTION
![Screenshot from 2019-10-07 14-06-30](https://user-images.githubusercontent.com/34790378/66296704-c75a3280-e90b-11e9-8d7e-9f406c640e4f.png)

This commit enables passing REACT_APP `.env.production` variables while building and deploying to `surge.sh` with `GitHub actions`

Passing such variables will *override* values of variables in `client/.env` 