### PR TITLE
Fixes #31 Update script for surge.sh deploy

### DIFF
--- a/.github/workflows/surge.sh.yml
+++ b/.github/workflows/surge.sh.yml
@@ -21,7 +21,7 @@ jobs:
         run: 'yarn install'
       -
         name: 'Build react app'
-        run: 'yarn run build:web'
+        run: 'yarn run deploy:web'
         env:
           REACT_APP_API_ENDPOINT: ${{ secrets.REACT_APP_API_ENDPOINT }}
       -

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,8 @@
   "proxy": "http://localhost:3001/",
   "scripts": {
     "dev": "react-scripts start",
-    "build": "react-scripts build"
+    "build": "react-scripts build",
+    "deploy": "yarn run build && mv build/index.html build/200.html"
   },
   "dependencies": {
     "axios": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dev:web": "yarn workspace @hacktoberfest/client dev",
     "server": "yarn workspace @hacktoberfest/server server",
     "build:web": "yarn workspace @hacktoberfest/client build",
+    "deploy:web": "yarn workspace @hacktoberfest/client deploy",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -28,7 +28,7 @@ router.post(
 if (process.env.NODE_ENV === 'production') {
     // Handles any requests that don't match the ones above
     router.get('*', (req, res) => {
-        res.sendFile(path.join(`${__dirname}/../../client/build/index.html`));
+        res.sendFile(path.join(`${__dirname}/../../client/build/200.html`));
     });
 }
 


### PR DESCRIPTION
### What this PR solves?
- Surge.sh fails to load custom routes if visited directly to the route URL

### What Changed ?

- Rename `build/index.html` to `200.html` for surge to use fallback file on browsing to routes by `react-router-dom`
- This ensures that every URL falls back to that file.
