### PR TITLE
Added Gyroscope Support in Tilt.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
     "react-final-form-html5-validation": "^1.0.3",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0",
-    "react-tilt": "^0.1.4",
+    "react-parallax-tilt": "^1.3.23",
     "styled-components": "^4.4.0"
   },
   "browserslist": {

--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -143,7 +143,7 @@ const Footer = () => {
                         </div>
                     </Col>
                     <Col md={5} className="doc__logo--wrapper">
-                        <Tilt className="Tilt" gyroscope={true} tiltMaxAngleX={20} tiltMaxAngleY={20} scale={1.05}>
+                        <Tilt className="Tilt" gyroscope={true} tiltMaxAngleX={-10} tiltMaxAngleY={20} scale={1.05}>
                             <div className="Tilt-inner">
                                 <Image src={DOC} fluid />
                                 <p>Powered by TRACECEA</p>

--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Row, Col, Image, Container } from 'react-bootstrap';
 import styled from 'styled-components';
-import Tilt from 'react-tilt';
+import Tilt from 'react-parallax-tilt';
 
 import { domain, repoLink, twitterShare, githubLink, slackLink, instagramLink } from '../../config';
 import DOC from '../../static/Hacktoberfest_19_Events_lockup_ko_600x200.png';
@@ -143,7 +143,7 @@ const Footer = () => {
                         </div>
                     </Col>
                     <Col md={5} className="doc__logo--wrapper">
-                        <Tilt className="Tilt" options={{ max: 20, scale: 1.05 }}>
+                        <Tilt className="Tilt" gyroscope={true} tiltMaxAngleX={20} tiltMaxAngleY={20} scale={1.05}>
                             <div className="Tilt-inner">
                                 <Image src={DOC} fluid />
                                 <p>Powered by TRACECEA</p>

--- a/client/src/components/Home/HeroSection.js
+++ b/client/src/components/Home/HeroSection.js
@@ -64,7 +64,7 @@ const HeroSection = () => {
     return (
         <StyledRow>
             <Col md={7}>
-                <Tilt className="Tilt" gyroscope={true} tiltMaxAngleX={20} tiltMaxAngleY={20} scale={1.05}>
+                <Tilt className="Tilt" gyroscope={true} tiltMaxAngleX={-10} tiltMaxAngleY={20} scale={1.05}>
                     <div className="Tilt-inner">
                         <Image src={Logo} fluid />
                     </div>

--- a/client/src/components/Home/HeroSection.js
+++ b/client/src/components/Home/HeroSection.js
@@ -3,7 +3,7 @@ import { Image, Row, Col } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import parse from 'html-react-parser';
 import styled from 'styled-components';
-import Tilt from 'react-tilt';
+import Tilt from 'react-parallax-tilt';
 
 import Logo from '../../static/logo.svg';
 
@@ -64,7 +64,7 @@ const HeroSection = () => {
     return (
         <StyledRow>
             <Col md={7}>
-                <Tilt className="Tilt" options={{ max: 20, scale: 1.05 }}>
+                <Tilt className="Tilt" gyroscope={true} tiltMaxAngleX={20} tiltMaxAngleY={20} scale={1.05}>
                     <div className="Tilt-inner">
                         <Image src={Logo} fluid />
                     </div>


### PR DESCRIPTION
Replaced react-tilt with react-parallax-tilt.
You can disable Gyro Support by removing gyroscope={true} within the Tilt class.
Play around with tiltMaxAngleX and tiltMaxAngleY within the same class to get the desired effect.

